### PR TITLE
Add a defaultOptions() method

### DIFF
--- a/voiceit/VoiceIt2.php
+++ b/voiceit/VoiceIt2.php
@@ -11,9 +11,9 @@ class VoiceIt2 {
   public $platformId = '42';
 
   function __construct($key, $token, $customUrl = 'https://api.voiceit.io') {
-     $this->apiKey = $key;
-     $this->apiToken = $token;
-     $this->baseUrl = $customUrl;
+    $this->apiKey = $key;
+    $this->apiToken = $token;
+    $this->baseUrl = $customUrl;
   }
 
   function checkFileExists($file) {
@@ -23,336 +23,275 @@ class VoiceIt2 {
   }
 
   public function getVersion() {
-     return VoiceIt2::VERSION;
+    return VoiceIt2::VERSION;
   }
 
   public function addNotificationUrl($url) {
-     $this->notificationUrl = '?notificationURL='.urlencode($url);
+    $this->notificationUrl = '?notificationURL='.urlencode($url);
   }
 
   public function removeNotificationUrl() {
-     $this->notificationUrl = '';
+    $this->notificationUrl = '';
   }
 
   public function getNotificationUrl() {
-     return $this->notificationUrl;
+    return $this->notificationUrl;
+  }
+
+  protected function createHandler(){
+    $crl = curl_init();
+
+    $this->setDefaultOptions($crl);
+
+    return $crl;
+  }
+
+  protected function setDefaultOptions(&$crl){
+    curl_setopt($crl, CURLOPT_USERPWD, "$this->api_key:$this->api_token");
+    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
+    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
   }
 
   public function getPhrases($contentLanguage) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/phrases/'.$contentLanguage.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'GET');
     return curl_exec($crl);
   }
 
   public function getAllUsers() {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/users'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'GET');
     return curl_exec($crl);
   }
 
   public function createUser() {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/users'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'POST');
     return curl_exec($crl);
   }
 
   public function checkUserExists($userId) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/users/'.$userId.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'GET');
     return curl_exec($crl);
   }
 
   public function deleteUser($userId) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/users/'.$userId.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'DELETE');
     return curl_exec($crl);
   }
 
   public function getGroupsForUser($userId) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/users/'.$userId.'/groups'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'GET');
     return curl_exec($crl);
   }
 
   public function deleteAllEnrollments($userId) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/enrollments/'.$userId.'/all'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'DELETE');
     return curl_exec($crl);
   }
 
   public function getAllVoiceEnrollments($userId) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/enrollments/voice/'.$userId.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'GET');
     return curl_exec($crl);
   }
 
   public function getAllFaceEnrollments($userId) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/enrollments/face/'.$userId.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'GET');
     return curl_exec($crl);
   }
 
   public function getAllVideoEnrollments($userId) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/enrollments/video/'.$userId.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'GET');
     return curl_exec($crl);
   }
 
-	public function createVoiceEnrollment($userId, $contentLanguage, $phrase, $filePath) {
+  public function createVoiceEnrollment($userId, $contentLanguage, $phrase, $filePath) {
     $this->checkFileExists($filePath);
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/enrollments/voice'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'POST');
     $fields = [
-      'userId' => $userId,
-      'contentLanguage' => $contentLanguage,
-      'phrase' => $phrase,
-      'recording' => curl_file_create($filePath)
+        'userId' => $userId,
+        'contentLanguage' => $contentLanguage,
+        'phrase' => $phrase,
+        'recording' => curl_file_create($filePath)
     ];
     curl_setopt($crl, CURLOPT_POSTFIELDS, $fields);
     return curl_exec($crl);
-	}
+  }
 
   public function createVoiceEnrollmentByUrl($userId, $contentLanguage, $phrase, $fileUrl) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/enrollments/voice/byUrl'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'POST');
     $fields = [
-      'userId' => $userId,
-      'contentLanguage' => $contentLanguage,
-      'phrase' => $phrase,
-      'fileUrl' => $fileUrl
+        'userId' => $userId,
+        'contentLanguage' => $contentLanguage,
+        'phrase' => $phrase,
+        'fileUrl' => $fileUrl
     ];
     curl_setopt($crl, CURLOPT_POSTFIELDS, $fields);
     return curl_exec($crl);
-	}
+  }
 
   public function createFaceEnrollment($userId, $filePath) {
     $this->checkFileExists($filePath);
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/enrollments/face'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'POST');
     $fields = [
-      'userId' => $userId,
-      'video' => curl_file_create($filePath)
+        'userId' => $userId,
+        'video' => curl_file_create($filePath)
     ];
     curl_setopt($crl, CURLOPT_POSTFIELDS, $fields);
     return curl_exec($crl);
-	}
+  }
 
   public function createFaceEnrollmentByUrl($userId, $fileUrl) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/enrollments/face/byUrl'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'POST');
     $fields = [
-      'userId' => $userId,
-      'fileUrl' => $fileUrl
+        'userId' => $userId,
+        'fileUrl' => $fileUrl
     ];
     curl_setopt($crl, CURLOPT_POSTFIELDS, $fields);
     return curl_exec($crl);
-	}
+  }
 
   public function createVideoEnrollment($userId, $contentLanguage, $phrase, $filePath) {
     $this->checkFileExists($filePath);
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/enrollments/video'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'POST');
     $fields = [
-      'userId' => $userId,
-      'contentLanguage' => $contentLanguage,
-      'phrase' => $phrase,
-      'video' => curl_file_create($filePath)
+        'userId' => $userId,
+        'contentLanguage' => $contentLanguage,
+        'phrase' => $phrase,
+        'video' => curl_file_create($filePath)
     ];
     curl_setopt($crl, CURLOPT_POSTFIELDS, $fields);
     return curl_exec($crl);
-	}
+  }
 
   public function createVideoEnrollmentByUrl($userId, $contentLanguage, $phrase, $fileUrl) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/enrollments/video/byUrl'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'POST');
     $fields = [
-      'userId' => $userId,
-      'contentLanguage' => $contentLanguage,
-      'phrase' => $phrase,
-      'fileUrl' => $fileUrl
+        'userId' => $userId,
+        'contentLanguage' => $contentLanguage,
+        'phrase' => $phrase,
+        'fileUrl' => $fileUrl
     ];
     curl_setopt($crl, CURLOPT_POSTFIELDS, $fields);
     return curl_exec($crl);
-	}
+  }
 
   public function getAllGroups() {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/groups'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'GET');
     return curl_exec($crl);
   }
 
   public function getGroup($groupId) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/groups/'.$groupId.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'GET');
     return curl_exec($crl);
   }
 
   public function groupExists($groupId) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/groups/'.$groupId.'/exists'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'GET');
     return curl_exec($crl);
   }
 
   public function createGroup($description) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/groups'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'POST');
     $fields = [
-      'description' => $description
+        'description' => $description
     ];
     curl_setopt($crl, CURLOPT_POSTFIELDS, $fields);
     return curl_exec($crl);
-	}
+  }
 
   public function addUserToGroup($groupId, $userId) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/groups/addUser'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'PUT');
     $fields = [
-      'groupId' => $groupId,
-      'userId' => $userId
+        'groupId' => $groupId,
+        'userId' => $userId
     ];
     curl_setopt($crl, CURLOPT_POSTFIELDS, $fields);
     return curl_exec($crl);
   }
 
   public function removeUserFromGroup($groupId, $userId) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/groups/removeUser'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'PUT');
     $fields = [
-      'groupId' => $groupId,
-      'userId' => $userId
+        'groupId' => $groupId,
+        'userId' => $userId
     ];
     curl_setopt($crl, CURLOPT_POSTFIELDS, $fields);
     return curl_exec($crl);
   }
 
   public function deleteGroup($groupId) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/groups/'.$groupId.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'DELETE');
     return curl_exec($crl);
   }
 
   public function voiceVerification($userId, $contentLanguage, $phrase, $filePath) {
     $this->checkFileExists($filePath);
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/verification/voice'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'POST');
     $fields = [
-      'userId' => $userId,
-      'contentLanguage' => $contentLanguage,
-      'phrase' => $phrase,
-      'recording' => curl_file_create($filePath)
+        'userId' => $userId,
+        'contentLanguage' => $contentLanguage,
+        'phrase' => $phrase,
+        'recording' => curl_file_create($filePath)
     ];
     curl_setopt($crl, CURLOPT_POSTFIELDS, $fields);
     return curl_exec($crl);
   }
 
   public function voiceVerificationByUrl($userId, $contentLanguage, $phrase, $fileUrl) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/verification/voice/byUrl'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'POST');
     $fields = [
-      'userId' => $userId,
-      'contentLanguage' => $contentLanguage,
-      'phrase' => $phrase,
-      'fileUrl' => $fileUrl
+        'userId' => $userId,
+        'contentLanguage' => $contentLanguage,
+        'phrase' => $phrase,
+        'fileUrl' => $fileUrl
     ];
     curl_setopt($crl, CURLOPT_POSTFIELDS, $fields);
     return curl_exec($crl);
@@ -360,30 +299,24 @@ class VoiceIt2 {
 
   public function faceVerification($userId, $filePath) {
     $this->checkFileExists($filePath);
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/verification/face'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'POST');
     $fields = [
-      'userId' => $userId,
-      'video' => curl_file_create($filePath)
+        'userId' => $userId,
+        'video' => curl_file_create($filePath)
     ];
     curl_setopt($crl, CURLOPT_POSTFIELDS, $fields);
     return curl_exec($crl);
   }
 
   public function faceVerificationByUrl($userId, $fileUrl) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/verification/face/byUrl'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'POST');
     $fields = [
-      'userId' => $userId,
-      'fileUrl' => $fileUrl
+        'userId' => $userId,
+        'fileUrl' => $fileUrl
     ];
     curl_setopt($crl, CURLOPT_POSTFIELDS, $fields);
     return curl_exec($crl);
@@ -391,34 +324,28 @@ class VoiceIt2 {
 
   public function videoVerification($userId, $contentLanguage, $phrase, $filePath) {
     $this->checkFileExists($filePath);
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/verification/video'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'POST');
     $fields = [
-      'userId' => $userId,
-      'contentLanguage' => $contentLanguage,
-      'phrase' => $phrase,
-      'video' => curl_file_create($filePath)
+        'userId' => $userId,
+        'contentLanguage' => $contentLanguage,
+        'phrase' => $phrase,
+        'video' => curl_file_create($filePath)
     ];
     curl_setopt($crl, CURLOPT_POSTFIELDS, $fields);
     return curl_exec($crl);
   }
 
   public function videoVerificationByUrl($userId, $contentLanguage, $phrase, $fileUrl) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/verification/video/byUrl'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'POST');
     $fields = [
-      'userId' => $userId,
-      'contentLanguage' => $contentLanguage,
-      'phrase' => $phrase,
-      'fileUrl' => $fileUrl
+        'userId' => $userId,
+        'contentLanguage' => $contentLanguage,
+        'phrase' => $phrase,
+        'fileUrl' => $fileUrl
     ];
     curl_setopt($crl, CURLOPT_POSTFIELDS, $fields);
     return curl_exec($crl);
@@ -426,34 +353,28 @@ class VoiceIt2 {
 
   public function voiceIdentification($groupId, $contentLanguage, $phrase, $filePath) {
     $this->checkFileExists($filePath);
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/identification/voice'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'POST');
     $fields = [
-      'groupId' => $groupId,
-      'contentLanguage' => $contentLanguage,
-      'phrase' => $phrase,
-      'recording' => curl_file_create($filePath)
+        'groupId' => $groupId,
+        'contentLanguage' => $contentLanguage,
+        'phrase' => $phrase,
+        'recording' => curl_file_create($filePath)
     ];
     curl_setopt($crl, CURLOPT_POSTFIELDS, $fields);
     return curl_exec($crl);
   }
 
   public function voiceIdentificationByUrl($groupId, $contentLanguage, $phrase, $fileUrl) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/identification/voice/byUrl'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'POST');
     $fields = [
-      'groupId' => $groupId,
-      'contentLanguage' => $contentLanguage,
-      'phrase' => $phrase,
-      'fileUrl' => $fileUrl
+        'groupId' => $groupId,
+        'contentLanguage' => $contentLanguage,
+        'phrase' => $phrase,
+        'fileUrl' => $fileUrl
     ];
     curl_setopt($crl, CURLOPT_POSTFIELDS, $fields);
     return curl_exec($crl);
@@ -461,30 +382,24 @@ class VoiceIt2 {
 
   public function faceIdentification($groupId, $filePath) {
     $this->checkFileExists($filePath);
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/identification/face'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'POST');
     $fields = [
-      'groupId' => $groupId,
-      'video' => curl_file_create($filePath)
+        'groupId' => $groupId,
+        'video' => curl_file_create($filePath)
     ];
     curl_setopt($crl, CURLOPT_POSTFIELDS, $fields);
     return curl_exec($crl);
   }
 
   public function faceIdentificationByUrl($groupId, $fileUrl) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/identification/face/byUrl'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'POST');
     $fields = [
-      'groupId' => $groupId,
-      'fileUrl' => $fileUrl
+        'groupId' => $groupId,
+        'fileUrl' => $fileUrl
     ];
     curl_setopt($crl, CURLOPT_POSTFIELDS, $fields);
     return curl_exec($crl);
@@ -492,34 +407,28 @@ class VoiceIt2 {
 
   public function videoIdentification($groupId, $contentLanguage, $phrase, $filePath) {
     $this->checkFileExists($filePath);
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/identification/video'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'POST');
     $fields = [
-      'groupId' => $groupId,
-      'contentLanguage' => $contentLanguage,
-      'phrase' => $phrase,
-      'video' => curl_file_create($filePath)
+        'groupId' => $groupId,
+        'contentLanguage' => $contentLanguage,
+        'phrase' => $phrase,
+        'video' => curl_file_create($filePath)
     ];
     curl_setopt($crl, CURLOPT_POSTFIELDS, $fields);
     return curl_exec($crl);
   }
 
   public function videoIdentificationByUrl($groupId, $contentLanguage, $phrase, $fileUrl) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/identification/video/byUrl'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'POST');
     $fields = [
-      'groupId' => $groupId,
-      'contentLanguage' => $contentLanguage,
-      'phrase' => $phrase,
-      'fileUrl' => $fileUrl
+        'groupId' => $groupId,
+        'contentLanguage' => $contentLanguage,
+        'phrase' => $phrase,
+        'fileUrl' => $fileUrl
     ];
     curl_setopt($crl, CURLOPT_POSTFIELDS, $fields);
     return curl_exec($crl);
@@ -527,87 +436,66 @@ class VoiceIt2 {
 
 
   public function createUserToken($userId, $secondsToTimeout) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/users/'.$userId.'/token?timeOut='.strval($secondsToTimeout));
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'POST');
     return curl_exec($crl);
   }
 
   public function expireUserTokens($userId) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/users/'.$userId.'/expireTokens');
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'POST');
     return curl_exec($crl);
   }
 
   public function createUnmanagedSubAccount($firstName, $lastName, $email, $password, $contentLanguage) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/subaccount/unmanaged'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'POST');
     $fields = [
-          'firstName' => $firstName,
-          'lastName' => $lastName,
-          'email' => $email,
-          'password' => $password,
-          'contentLanguage' => $contentLanguage
-        ];
+        'firstName' => $firstName,
+        'lastName' => $lastName,
+        'email' => $email,
+        'password' => $password,
+        'contentLanguage' => $contentLanguage
+    ];
     curl_setopt($crl, CURLOPT_POSTFIELDS, $fields);
     return curl_exec($crl);
   }
 
   public function createManagedSubAccount($firstName, $lastName, $email, $password, $contentLanguage) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/subaccount/managed'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'POST');
     $fields = [
-          'firstName' => $firstName,
-          'lastName' => $lastName,
-          'email' => $email,
-          'password' => $password,
-          'contentLanguage' => $contentLanguage
-        ];
+        'firstName' => $firstName,
+        'lastName' => $lastName,
+        'email' => $email,
+        'password' => $password,
+        'contentLanguage' => $contentLanguage
+    ];
     curl_setopt($crl, CURLOPT_POSTFIELDS, $fields);
     return curl_exec($crl);
   }
 
   public function switchSubAccountType($firstName) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/subaccount/'.$firstName.'/switchType'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'POST');
     return curl_exec($crl);
   }
 
   public function regenerateSubAccountAPIToken($subAccountAPIKey) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/subaccount/'.$subAccountAPIKey.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'POST');
     return curl_exec($crl);
   }
 
   public function deleteSubAccount($subAccountAPIKey) {
-    $crl = curl_init();
+    $crl = createHandler();
     curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/subaccount/'.$subAccountAPIKey.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'DELETE');
     return curl_exec($crl);
   }


### PR DESCRIPTION
I have run into a scenario where I need to add additional `curl_setopt()` configurations in order for my environment to properly communicate with the VoiceIt API. One workaround that I have made locally is moving most of the repeating `curl_setopt()` calls to a `setDefaultOptions()` function which is then overrideable to have additional options be used. In my case, it was the need to disable SSL checks for one of my dev instances so that it would proceed down the network pipeline to the VoiceIt API.

```
      curl_setopt($crl, CURLOPT_SSL_VERIFYHOST, false);
      curl_setopt($crl, CURLOPT_SSL_VERIFYPEER, false);
```

I'd prefer to not have to manage my own a locally-modified version of this class for the long-term. Can this type of behavior I've described and submitted be added in to the main branch?