### PR TITLE
Remove switchSubAccountType (dead endpoint)

### DIFF
--- a/tests/Tests.php
+++ b/tests/Tests.php
@@ -182,12 +182,6 @@ $responseCode = $ret ->{"responseCode"};
 AssertEqual("SUCC", $responseCode, __LINE__);
 $subaccountUnmanagedAPIKey = $ret ->{"apiKey"};
 
-$ret = json_decode($myVoiceIt->switchSubAccountType($subaccountUnmanagedAPIKey));
-$status = $ret ->{"status"};
-AssertEqual(200, $status, __LINE__);
-$responseCode = $ret ->{"responseCode"};
-AssertEqual("SUCC", $responseCode, __LINE__);
-
 $ret = json_decode($myVoiceIt->createManagedSubAccount("test", "php", "", "", ""));
 $status = $ret ->{"status"};
 $message = $ret ->{"message"};

--- a/voiceit/VoiceIt2.php
+++ b/voiceit/VoiceIt2.php
@@ -582,15 +582,6 @@ class VoiceIt2 {
     return curl_exec($crl);
   }
 
-  public function switchSubAccountType($firstName) {
-    $crl = curl_init();
-    curl_setopt($crl, CURLOPT_URL, $this->baseUrl.'/subaccount/'.$firstName.'/switchType'.$this->notificationUrl);
-    curl_setopt($crl, CURLOPT_USERPWD, "$this->apiKey:$this->apiToken");
-    curl_setopt($crl, CURLOPT_HTTPHEADER, array('platformId: '.$this->platformId, 'platformVersion: '.VoiceIt2::VERSION));
-    curl_setopt($crl, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt($crl, CURLOPT_CUSTOMREQUEST, 'POST');
-    return curl_exec($crl);
-  }
 
   public function regenerateSubAccountAPIToken($subAccountAPIKey) {
     $crl = curl_init();


### PR DESCRIPTION
## Summary
- Removes `switchSubAccountType()` method from `VoiceIt2.php` — calls non-existent `/subaccount/{key}/switchType` endpoint
- Removes corresponding test assertions

## Test plan
- [ ] Verify no remaining references to `switchType` in codebase
- [ ] Run existing sub-account tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)